### PR TITLE
Add PORT env var so it works on Heroku

### DIFF
--- a/services/billing/main.go
+++ b/services/billing/main.go
@@ -56,9 +56,14 @@ func main() {
 
 	loggedRouter := handlers.LoggingHandler(os.Stdout, Router)
 
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8000"
+	}
+
 	srv := &http.Server{
 		Handler: loggedRouter,
-		Addr:    "127.0.0.1:8000",
+		Addr:    ":" + port,
 	}
 
 	srv.ListenAndServe()

--- a/services/ui/lib/ui/application.ex
+++ b/services/ui/lib/ui/application.ex
@@ -6,7 +6,8 @@ defmodule Ui.Application do
 
   def start(_type, _args) do
     children = [
-      {Plug.Cowboy, scheme: :http, plug: Ui, options: [port: 4001]}
+      {Plug.Cowboy, scheme: :http, plug: Ui, 
+        options: [port: String.to_integer(System.get_env("PORT") || "4001")]}
     ]
 
     opts = [strategy: :one_for_one, name: Ui.Supervisor]

--- a/services/users/app.rb
+++ b/services/users/app.rb
@@ -18,6 +18,6 @@ end
 
 post '/users' do
   user = JSON.parse(request.body.read)
-
   Users.add(user['name'])
+  Users.list_all.to_json
 end

--- a/start.sh
+++ b/start.sh
@@ -2,4 +2,4 @@
 
 (cd services/billing && go build -o /tmp/billing-server && chmod +x /tmp/billing-server && /tmp/billing-server &)
 (cd services/users && bundle exec ruby app.rb &)
-(cd services/ui && mix run --ho-halt &)
+(cd services/ui && mix run --no-halt &)


### PR DESCRIPTION
I want to deploy the services in Heroku. Heroku exports a PORT env var that the app should bind to. This PR adds support for the env var on billing and ui services (users already bind to $PORT)