### PR TITLE
Support for heroku deployment

### DIFF
--- a/services/billing/main.go
+++ b/services/billing/main.go
@@ -56,10 +56,16 @@ func main() {
 
 	loggedRouter := handlers.LoggingHandler(os.Stdout, Router)
 
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8000"
+	}
+
 	srv := &http.Server{
 		Handler: loggedRouter,
-		Addr:    "127.0.0.1:8000",
+		Addr:    ":" + port,
 	}
 
 	srv.ListenAndServe()
+
 }

--- a/services/ui/lib/ui/application.ex
+++ b/services/ui/lib/ui/application.ex
@@ -6,7 +6,8 @@ defmodule Ui.Application do
 
   def start(_type, _args) do
     children = [
-      {Plug.Cowboy, scheme: :http, plug: Ui, options: [port: 4001]}
+      {Plug.Cowboy, scheme: :http, plug: Ui, 
+        options: [port: String.to_integer(System.get_env("PORT") || "4001")]}
     ]
 
     opts = [strategy: :one_for_one, name: Ui.Supervisor]


### PR DESCRIPTION
Heroku expects applications to bind dynamically to $PORT. This PR adds support for this. When no $PORT is set, services will bind to the expected default ports.